### PR TITLE
Update metadata.json GitHub Link

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     },
     "license": "CC-BY-SA-4.0",
     "resources": {
-        "Github": "https://github.com/perigoso/keyswitch-kicad-library"
+        "Github": "https://github.com/kiswitch/keyswitch-kicad-library"
     },
     "tags": [
         "footprint",


### PR DESCRIPTION
KiCad currently shows the old repository URL, which led me to question if the plugin on the official plugin manager is up to date and led to a short excursion to find out that it actually is.

To avoid this confusion in the future I'd like to update the GitHub Resource Link to point to the new repository, so that I can quickly find up to date documentation.